### PR TITLE
Apply original modification time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 [dependencies]
 byteorder = "1.4.3"
 log = "0.4"
+filetime_creation = "0.1"
 
 [lib]
 name = "mp4_merge"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -2,8 +2,8 @@
 // Copyright © 2022 Adrian <adrian.eddy at gmail>
 
 use std::io::Write;
-use std::path::Path;
-use mp4_merge::join_files;
+use std::path::*;
+use mp4_merge::{join_files, update_file_times};
 
 fn main() {
     let _time = std::time::Instant::now();
@@ -33,12 +33,16 @@ fn main() {
     if files.is_empty() { eprintln!("No input files!"); return; }
     if output_file.is_none() { eprintln!("Output file not specified!"); return; }
 
-    println!("Output file {:?}", output_file.as_ref().unwrap());
+    let final_output_file = output_file.as_ref().unwrap();
+    
+    println!("Output file {:?}", final_output_file);
 
-    join_files(&files, output_file.unwrap(), |progress| {
+    join_files(&files, final_output_file, |progress| {
         print!("\rMerging... {:.2}%", progress * 100.0);
         std::io::stdout().flush().unwrap();
     }).unwrap();
+
+    update_file_times(&files[0], final_output_file);
 
     println!("\rDone in {:.3}s                ", _time.elapsed().as_millis() as f64 / 1000.0);
     std::io::stdout().flush().unwrap();


### PR DESCRIPTION
Finally found some time to make this tool set the modification time of the merged output file to the original one. 

I didn't apply all the cross platform and file safety logic that has been built into gyroflow itself recently, don't know if it is necessary in this lib. 